### PR TITLE
Changes to help with new requirement for authentication on lint API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 ## gitlab-ci-validate
+
 This tool uses GitLab's CI [config validation API endpoint](https://docs.gitlab.com/ce/api/lint.html) to validate local config files.
 
 If you don't want to use the command line, you can paste your config into `https://gitlab.com/<your project>/-/ci/lint` [[ref](https://docs.gitlab.com/ee/ci/yaml/#validate-the-gitlab-ciyml)]
 
 ### Usage
+
 One or more `.gitlab-ci.yml` are passed as arguments on the command line. Any errors will result in a non-zero exit code. The filename must end in `.yml` to pass, but doesn't have to be `.gitlab-ci.yml`.
+An access token must be provided in order to authenticate throw gitlab API. [Here to generate one](https://gitlab.com/-/profile/personal_access_tokens).
+
 ```text
-$ gitlab-ci-validate ./good.yml ./maybe-good.yml ./bad.yml
+$ gitlab-ci-validate --token=ACCESS_TOKEN ./good.yml ./maybe-good.yml ./bad.yml
 PASS: ./good.yml
 SOFT FAIL: ./maybe-good.yml
  - Post https://gitlab.com/api/v4/ci/lint: dial tcp: lookup gitlab.com on 127.0.0.53:53: read udp 127.0.0.1:41487->127.0.0.53:53: i/o timeout
@@ -16,26 +20,28 @@ HARD FAIL: ./bad.yml
 
 Each input file will be validated and one of 3 results will be printed for it:
 
- - _PASS_ - the file passed all checks
- - _SOFT FAIL_ - the file is acessable and contains valid YAML, but there was an error contacting the validation API
- - _HARD FAIL_ - the file failed any checks
+- _PASS_ - the file passed all checks
+- _SOFT FAIL_ - the file is acessable and contains valid YAML, but there was an error contacting the validation API
+- _HARD FAIL_ - the file failed any checks
 
 The exit code will be:
 
- - 0 if all files are valid (all _PASS_)
- - 1 if any files are invalid (any _HARD FAIL_)
- - 2 if there was any _SOFT FAIL_ and no _HARD FAIL_
+- 0 if all files are valid (all _PASS_)
+- 1 if any files are invalid (any _HARD FAIL_)
+- 2 if there was any _SOFT FAIL_ and no _HARD FAIL_
 
 ### Using private GitLab host
+
 You can also use a private GitLab host both as a flag or as an environment variable.
 The following are equivalent.
 
 ```
-gitlab-ci-validate --host=http://user:pass@127.0.0.1:8080 .gitlab-ci.yml
+gitlab-ci-validate --token=ACCESS_TOKEN --host=http://user:pass@127.0.0.1:8080 .gitlab-ci.yml
 ```
 
 ```
 export GITLAB_HOST=http://user:pass@127.0.0.1:8080
+export GITLAB_TOKEN=XXXXXXX
 gitlab-ci-validate .gitlab-ci.yml
 ```
 
@@ -43,16 +49,20 @@ The flag has precedence over the environment variable.
 When not specified the host used is by default `https://gitlab.com`
 
 ### Installation
+
 You can either use a premade binary from the [releases page](https://github.com/Code0x58/gitlab-ci-validate/releases) or you can install it using `go get`:
+
 ```sh
 go get -u github.com/Code0x58/gitlab-ci-validate
 ```
 
 #### Usage with Docker containers
+
 You can use the Dockerfile to build your own image or use the pre-built version available at the [Gitlab container registry](https://gitlab.com/comedian780/docker-gitlab-ci-validate/container_registry).
 
 You can run tests against the gitlab.com endpoint:  
 If no parameter is given the container will look for a file called `.gitlab-ci.yml`
+
 ```sh
 docker run -i --rm \
 -v ${PWD}/.gitlab-ci.yml:/yaml/.gitlab-ci.yml \
@@ -60,7 +70,8 @@ registry.gitlab.com/comedian780/docker-gitlab-ci-validate
 ```
 
 You can run tests against a self hosted Gitlab instance with custom filenames:  
-Set the credentials and URL via the `GITLAB_HOST` environment variable  
+Set the credentials and URL via the `GITLAB_HOST` environment variable
+
 ```sh
 docker run -i --rm \
 -e GITLAB_HOST=https://GITLAB_USER:GITLAB_PW@your.gitlab.server \
@@ -70,6 +81,7 @@ registry.gitlab.com/comedian780/docker-gitlab-ci-validate custom.yml .files.yaml
 ```
 
 You can also test all YAML files inside a directory (this also includes YAML files in subdirectories):
+
 ```sh
 find . -type f -regex ".*\.\(yaml\|yml\|YAML\|YML\)" | xargs echo | xargs -I {} \
 docker run -i --rm \

--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@ If you don't want to use the command line, you can paste your config into `https
 
 ### Usage
 
+> :warning: Since GitLab 13.7.7 (2021-02-11) authentication is required, so you will need to use `--token=$ACCESS_TOKEN` or `--host=http://$username:$password@gitlab.com`
+
 One or more `.gitlab-ci.yml` are passed as arguments on the command line. Any errors will result in a non-zero exit code. The filename must end in `.yml` to pass, but doesn't have to be `.gitlab-ci.yml`.
-An access token must be provided in order to authenticate throw gitlab API. [Here to generate one](https://gitlab.com/-/profile/personal_access_tokens).
+
+An access token must be provided in order to authenticate with the gitlab API. You can see your access tokens through [your profile settings](https://gitlab.com/-/profile/personal_access_tokens). The token must have at least the "api" scope.
 
 ```text
 $ gitlab-ci-validate --token=ACCESS_TOKEN ./good.yml ./maybe-good.yml ./bad.yml
@@ -36,12 +39,12 @@ You can also use a private GitLab host both as a flag or as an environment varia
 The following are equivalent.
 
 ```
-gitlab-ci-validate --token=ACCESS_TOKEN --host=http://user:pass@127.0.0.1:8080 .gitlab-ci.yml
+gitlab-ci-validate --token=$ACCESS_TOKEN --host=http://user:pass@127.0.0.1:8080 .gitlab-ci.yml
 ```
 
 ```
 export GITLAB_HOST=http://user:pass@127.0.0.1:8080
-export GITLAB_TOKEN=XXXXXXX
+export GITLAB_TOKEN=$ACCESS_TOKEN
 gitlab-ci-validate .gitlab-ci.yml
 ```
 

--- a/gitlab-ci-validate.go
+++ b/gitlab-ci-validate.go
@@ -38,7 +38,7 @@ func init() {
 }
 
 // Validate the given file
-func ValidateFile(host string, token string, path string) (Validation, []error) {
+func ValidateFile(hostUrl url.URL, path string) (Validation, []error) {
 	content, err := ioutil.ReadFile(path)
 	if err != nil {
 		return HARD_FAIL, []error{err}
@@ -54,7 +54,8 @@ func ValidateFile(host string, token string, path string) (Validation, []error) 
 	}
 
 	values := url.Values{"content": {string(data)}}
-	request, err := http.NewRequest("POST", fmt.Sprintf("%s/api/v4/ci/lint?private_token=%s", host, token), strings.NewReader(values.Encode()))
+	hostUrl.Path = "/api/v4/ci/lint"
+	request, err := http.NewRequest("POST", hostUrl.String(), strings.NewReader(values.Encode()))
 	if err != nil {
 		return SOFT_FAIL, []error{err}
 	}
@@ -65,8 +66,12 @@ func ValidateFile(host string, token string, path string) (Validation, []error) 
 		return SOFT_FAIL, []error{err}
 	}
 	defer response.Body.Close()
+	if response.StatusCode == 401 {
+		fmt.Printf("HTTP 401 recieved from %s, authentication is required. See usage on how to provide an identity if you have not already, otherwise double check your basic auth or token.\n", hostUrl.Host)
+		os.Exit(1)
+	}
 	if response.StatusCode != 200 {
-		return SOFT_FAIL, []error{fmt.Errorf("Non-200 status from GitLab: %d", response.StatusCode)}
+		return SOFT_FAIL, []error{fmt.Errorf("Non-200 status from %s for %s: %d", hostUrl.Host, hostUrl.Path, response.StatusCode)}
 	}
 
 	responseBytes, err := ioutil.ReadAll(response.Body)
@@ -99,10 +104,28 @@ func main() {
 		flag.PrintDefaults()
 	}
 
-	token := flag.String("token", getEnv("GITLAB_TOKEN", "NULL"), "GitLab token to authentificate")
+	token := flag.String("token", getEnv("GITLAB_TOKEN", ""), "GitLab API access token")
 
 	host := flag.String("host", getEnv("GITLAB_HOST", "https://gitlab.com"), "GitLab instance used to validate the config files")
 	flag.Parse()
+
+	baseUrl, err := url.Parse(*host)
+	if err != nil {
+		fmt.Printf("host is not valid URL: %s\n", *host)
+		os.Exit(1)
+	}
+	if baseUrl.Scheme == "" {
+		baseUrl.Scheme = "https"
+		// this is because the baseUrl.Host is not set when the scheme is no present
+		baseUrl, err = url.Parse(baseUrl.String())
+		if err != nil {
+			fmt.Printf("host is not a valid URL: %s\n", *host)
+		}
+	}
+	if *token != "" {
+		params := url.Values{"private_token": {*token}}
+		baseUrl.RawQuery = params.Encode()
+	}
 
 	l := log.New(os.Stderr, "", 0)
 	if flag.NArg() < 1 {
@@ -112,7 +135,7 @@ func main() {
 
 	var result Validation
 	for _, source := range flag.Args() {
-		validation, errs := ValidateFile(*host, *token, source)
+		validation, errs := ValidateFile(*baseUrl, source)
 		if validation > result {
 			result = validation
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/Code0x58/gitlab-ci-validate
 
+go 1.15
+
 require (
 	github.com/ghodss/yaml v1.0.0
 	gopkg.in/yaml.v2 v2.2.2 // indirect


### PR DESCRIPTION
This continues from #8 (which adds `--token` plus notes about needing auth) to give a helpful error message if a HTTP 401 is received and only sends the private token query parameter if explicitly given.

Fixes #11 