### PR TITLE
Update GitHub Actions to ubuntu-24.04 and modern action versions

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -2,19 +2,19 @@ name: Basic quality checks
 on: [push, pull_request]
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.20
-    - name: Fmt
-      run: gofmt -d ./
-    - name: Vet
-      run: go vet ./
-    - name: Build
-      run: go build
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.20'
+      - name: Fmt
+        run: gofmt -d ./
+      - name: Vet
+        run: go vet ./
+      - name: Build
+        run: go build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,28 +4,33 @@ on:
     tags: ['*']
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      packages: write
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.20
-    - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v5.0.0
-      with:
-        version: v1.21.2
-        args: release --clean
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Push Docker image
-      uses: docker/build-push-action@v1
-      with:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-        registry: ghcr.io
-        repository: code0x58/gitlab-ci-validate/gitlab-ci-validate
-        tag_with_ref: true
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.20'
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v1'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation
- Bring workflows up-to-date with the latest GitHub-hosted LTS runner and action APIs to avoid breakage from ecosystem changes. 
- Ensure release workflow has the permissions and auth flow expected by current GitHub Actions and GHCR usage.

### Description
- Updated both workflows to run on `runs-on: ubuntu-24.04` and normalized YAML indentation. 
- Upgraded core actions to current majors: `actions/checkout@v4` and `actions/setup-go@v5` and quoted the `go-version` as `'1.20'`. 
- Modernized the release pipeline by adding `permissions: contents: write` and `packages: write`, replacing the old Docker push step with `docker/login-action@v3`, and switching to `goreleaser/goreleaser-action@v6` with `distribution: goreleaser` and `version: '~> v1'`. 

### Testing
- Validated both workflow files parse as YAML using `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/check.yaml'); YAML.load_file('.github/workflows/release.yaml'); puts 'YAML OK'"`, which printed `YAML OK` indicating success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69946706a2c4832284aa3774b619e2b8)