### PR TITLE
Handle CLI argument parsing failures as exit code 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Each input file will be validated and one of 3 results will be printed for it:
 The exit code will be:
 
 - 0 if all files are valid (all _PASS_)
-- 1 if any files are invalid (any _HARD FAIL_)
+- 1 if there are bad CLI args or if any files are invalid (any _HARD FAIL_)
 - 2 if there was any _SOFT FAIL_ and no _HARD FAIL_
 
 ## Using private GitLab host


### PR DESCRIPTION
### Motivation
- The default `flag` package emits its own error and exits with code `2` on parse failures, which prevents the program from controlling exit semantics and conflicts with the desired behavior of using exit code `1` for invalid CLI usage or hard failures.

### Description
- Replace the package-global `flag` usage with a dedicated `flag.NewFlagSet(..., flag.ContinueOnError)` so parse errors can be handled by our code. 
- Suppress the flag package automatic output with `flags.SetOutput(io.Discard)` and explicitly print the parse error and call `os.Exit(1)` on parse failure. 
- Update all flag accesses from package-global helpers to the local `flags` instance (`Usage`, `NArg`, `Args`) to keep behavior consistent. 
- Update `README.md` to document that bad CLI args also return exit code `1`.

### Testing
- Ran `go test ./...` which succeeded (no test files present). 
- Built the binary with `go build -o /tmp/gitlab-ci-validate .` which succeeded. 
- Executed `/tmp/gitlab-ci-validate --not-a-real-flag` and confirmed it returns `EXIT:1` and prints usage/error as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69947e0fbba48322a4c1b7018a58f123)