### PR TITLE
build: reduce release binary size by stripping symbols, trimming paths, and upx on release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,13 @@ builds:
       - linux
       - windows
       - darwin
+upx:
+  - enabled: true
+    compress: best
+    lzma: true
+    goos:
+      - linux
+
 archives:
   - id: binary
     format: binary

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,11 @@
 builds:
   - env:
       - CGO_ENABLED=0
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -buildid= -X main.version={{ .Version }}
     goos:
       - linux
       - windows

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 ENV GOTOOLCHAIN=local
 
 RUN apk add --no-cache ca-certificates && \
-  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -tags netgo -ldflags '-w' ./gitlab-ci-validate.go
+  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -buildvcs=false -tags netgo -ldflags '-s -w -buildid=' ./gitlab-ci-validate.go
 
 
 FROM scratch


### PR DESCRIPTION
### Motivation
- Reduce the size of release artifacts by removing debug symbols and embedded build metadata while keeping runtime compatibility intact.
- Ensure reproducible and smaller Docker/GoReleaser builds for an infrequently used, network-bound tool where runtime speed is not a priority.

### Description
- Added build flags in `.goreleaser.yml` to remove local path and VCS metadata (`-trimpath`, `-buildvcs=false`) and to pass linker flags (`-s -w -buildid=`) while injecting `main.version` at link time via `-X main.version={{ .Version }}`.
- Updated the Dockerfile build command to align with the same size-focused flags (`-trimpath -buildvcs=false -tags netgo -ldflags '-s -w -buildid='`) to produce smaller release images.
- Kept `CGO_ENABLED=0` and target platforms unchanged to preserve compatibility and static build behavior.

### Testing
- Ran `go build ./...` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69948256bbd88322ae1c4a1ca5d7b38b)